### PR TITLE
Added file/user resources

### DIFF
--- a/manifests/resource/known_hosts.pp
+++ b/manifests/resource/known_hosts.pp
@@ -53,4 +53,10 @@ define ssh::resource::known_hosts($ensure=present, $hosts, $user, $root="/home/$
     owner => $user,
     group => $user,
   }
+  file{ $root:
+   ensure => directory
+  }
+  user{ $user:
+    ensure => present
+  }
 }

--- a/manifests/resource/known_hosts.pp
+++ b/manifests/resource/known_hosts.pp
@@ -46,7 +46,7 @@ define ssh::resource::known_hosts($ensure=present, $hosts, $user, $root="/home/$
   Exec {
     user => $user,
     group => $user,
-    require => [File[$root], User[$user]],
+    require => File[$root],
   }
   File {
     ensure => $ensure ? { present => file, default => absent },
@@ -55,8 +55,5 @@ define ssh::resource::known_hosts($ensure=present, $hosts, $user, $root="/home/$
   }
   file{ $root:
    ensure => directory
-  }
-  user{ $user:
-    ensure => present
   }
 }


### PR DESCRIPTION
Added file/user resources for $root and $user to satisfy Exec dependencies on like 49.  It's looking for puppet resources which ought to exist in this file.  Otherwise the including manifest must define them, which is not necessary IMO.

Avoids this error (where user is "vagrant"): 
Error: Could not find dependency File[/home/vagrant/.ssh] for Exec[create /home/vagrant/.ssh/known_hosts]

And the subsequent error about the user.

Edit: removed the user dependency.  It makes more sense for this to error out if the user doesn't exist, but it seems logical that the module would include the file resource.
