### PR TITLE
Allow module to manage "/etc/ssh/ssh_known_hosts" file.

### DIFF
--- a/manifests/resource/known_hosts.pp
+++ b/manifests/resource/known_hosts.pp
@@ -14,32 +14,32 @@
 #   *hosts*   - Comma separated list of hostnames to compile into known_hosts file.
 #   *user*    - User to create known_hosts file for.
 #  [*root*]   - Parent directory known_hosts file. Default /home/USER/.ssh
-define ssh::resource::known_hosts($ensure=present, $hosts, $user, $root="/home/$user/.ssh") {
+define ssh::resource::known_hosts($ensure=present, $hosts, $user, $root="/home/$user/.ssh", $known_hosts="$root/known_hosts", $known_hosts_mode='0600') {
   $hosthash = "$root/host_hash"
   $sed = "sed 's/,/\\n/g'"
-  $sha = "sha512sum"
+  $sha = 'sha512sum'
   $awk = "awk '{ print \$1 }'"
-  $hashcmd = "sha512sum | $awk"
-  $known_hosts = "$root/known_hosts"
 
   # Create the hosts' hash. When this file is re-created it will trigger the
   # exec of ssh-keyscan, which constructs the known_hosts file.
   exec { "create hash of hosts for $user in $root":
+    path => '/bin:/usr/bin:/bin:/usr/sbin:/sbin',
     command => "echo '$hosts' | $sha | $awk > $hosthash",
-    unless  => "[ -f $hosthash ] && [ `$sha $hosthash | $awk` = `echo '$hosts' | $sha | $awk | $sha | $awk` ]",
+    unless  => "[ -f $hosthash ] && [ `cat $hosthash` = `echo '$hosts' | $sha | $awk` ]",
   }
   file { $hosthash:
     mode => 0600,
   }
 
   # Construct the right and proper known_hosts file.
-  exec { "create $root/known_hosts":
-    command => "echo '$hosts' | $sed | ssh-keyscan -H -f - > $root/known_hosts",
+  exec { "create ${known_hosts}":
+    path => '/bin:/usr/bin:/bin:/usr/sbin:/sbin',
+    command => "echo '$hosts' | $sed | ssh-keyscan -H -f - > ${known_hosts}",
     refreshonly => true,
     subscribe => Exec["create hash of hosts for $user in $root"],
   }
   file { "${known_hosts}":
-    mode => 0600,
+    mode => $known_hosts_mode,
   }
 
   ## Ensure that all files and execs get the correct user/group combinations.


### PR DESCRIPTION
Allow module to manage "/etc/ssh/ssh_known_hosts" file.

```
ssh::resource::known_hosts { 'global-known-hosts':
  hosts               =>  'github.com,bitbucket.org',
  user                =>  'root',
  root                =>  '/etc/ssh',
  known_hosts         =>  '/etc/ssh/ssh_known_hosts',
  known_hosts_mode    =>  '0644',
}
```
