### PR TITLE
Add path environment for execution

### DIFF
--- a/manifests/resource/known_hosts.pp
+++ b/manifests/resource/known_hosts.pp
@@ -27,6 +27,7 @@ define ssh::resource::known_hosts($ensure=present, $hosts, $user, $root="/home/$
   exec { "create hash of hosts for $user in $root":
     command => "echo '$hosts' | $sha | $awk > $hosthash",
     unless  => "[ -f $hosthash ] && [ `$sha $hosthash | $awk` = `echo '$hosts' | $sha | $awk | $sha | $awk` ]",
+    path => [ "/bin/", "/sbin/" , "/usr/bin/", "/usr/sbin/" ],
   }
   file { $hosthash:
     mode => 0600,
@@ -37,6 +38,7 @@ define ssh::resource::known_hosts($ensure=present, $hosts, $user, $root="/home/$
     command => "echo '$hosts' | $sed | ssh-keyscan -H -f - > $root/known_hosts",
     refreshonly => true,
     subscribe => Exec["create hash of hosts for $user in $root"],
+    path => [ "/bin/", "/sbin/" , "/usr/bin/", "/usr/sbin/" ],
   }
   file { "${known_hosts}":
     mode => 0600,


### PR DESCRIPTION
When using this module with puppet on the vagrant box hashicorp/precise64, I experienced a bug with executing my puppet config:

```
...
ssh::resource::known_hosts { 'vagrant':
  hosts => 'host.xyz.org',
  user => 'vagrant',
}
...
```

Caused the following error:

Parameter unless failed: '[ -f /home/vagrant/.ssh/host_hash ] && [ `sha512sum /home/vagrant/.ssh/host_hash | awk '{ print $1 }'` = `echo 'host.xyz.org' | sha512sum | awk '{ print $1 }' | sha512sum | awk '{ print $1 }'` ]' is not qualified and no path was specified. Please qualify the command or specify a path.
